### PR TITLE
Added method which allows usage of ID placeholder in validation rules for more flexibility of 'unique' rule

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "way/database",
+    "name": "andreyco/database",
     "description": "",
     "authors": [
         {
@@ -18,7 +18,7 @@
     },
     "autoload": {
         "psr-0": {
-            "Way\\Database": "src/"
+            "Andreyco\\Database": "src/"
         }
     },
     "minimum-stability": "dev"

--- a/src/Andreyco/Database/DatabaseServiceProvider.php
+++ b/src/Andreyco/Database/DatabaseServiceProvider.php
@@ -1,4 +1,4 @@
-<?php namespace Way\Database;
+<?php namespace Andreyco\Database;
 
 use Illuminate\Support\ServiceProvider;
 

--- a/src/Andreyco/Database/Model.php
+++ b/src/Andreyco/Database/Model.php
@@ -1,4 +1,4 @@
-<?php namespace Way\Database;
+<?php namespace Andreyco\Database;
 
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Validation\Validator;
@@ -18,6 +18,13 @@ class Model extends Eloquent {
      * @var Array
      */
     protected static $rules = array();
+
+    /**
+     * Custom validation messages
+     *
+     * @var Array
+     */
+    protected static $messages = array();
 
     /**
      * Validator instance
@@ -51,7 +58,7 @@ class Model extends Eloquent {
      */
     public function validate()
     {
-        $v = $this->validator->make($this->attributes, $this->getRules());
+        $v = $this->validator->make($this->attributes, $this->getRules(), $this->getMessages());
 
         if ($v->passes())
         {
@@ -66,7 +73,7 @@ class Model extends Eloquent {
     /**
      * Process defined rules for more flexibility
      *
-     * @return array
+     * @return Array
      */
     public function getRules()
     {
@@ -84,6 +91,16 @@ class Model extends Eloquent {
         });
 
         return static::$rules;
+    }
+
+    /**
+     * Process defined custom messages for more flexibility
+     *
+     * @return Array
+     */
+    public function getMessages()
+    {
+        return static::$messages;
     }
 
     /**

--- a/src/Way/Database/Model.php
+++ b/src/Way/Database/Model.php
@@ -7,21 +7,21 @@ class Model extends Eloquent {
 
     /**
      * Error message bag
-     * 
+     *
      * @var Illuminate\Support\MessageBag
      */
     protected $errors;
 
     /**
      * Validation rules
-     * 
+     *
      * @var Array
      */
     protected static $rules = array();
 
     /**
      * Validator instance
-     * 
+     *
      * @var Illuminate\Validation\Validators
      */
     protected $validator;
@@ -51,7 +51,7 @@ class Model extends Eloquent {
      */
     public function validate()
     {
-        $v = $this->validator->make($this->attributes, static::$rules);
+        $v = $this->validator->make($this->attributes, $this->getRules());
 
         if ($v->passes())
         {
@@ -64,8 +64,31 @@ class Model extends Eloquent {
     }
 
     /**
+     * Process defined rules for more flexibility
+     *
+     * @return array
+     */
+    public function getRules()
+    {
+        if (empty(static::$rules)) {
+            return array();
+        }
+
+        // get the model's ID.
+        $id = $this->getKey() ?: 'NULL';
+
+        // Replace placeholders
+        array_walk(static::$rules, function(&$item) use ($id)
+        {
+            $item = str_ireplace(':id:', $id, $item);
+        });
+
+        return static::$rules;
+    }
+
+    /**
      * Set error message bag
-     * 
+     *
      * @var Illuminate\Support\MessageBag
      */
     protected function setErrors($errors)

--- a/tests/Database/ModelTest.php
+++ b/tests/Database/ModelTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use Way\Database\Model;
+use Andreyco\Database\Model;
 use Mockery as m;
 
 class ModelTest extends PHPUnit_Framework_TestCase {
@@ -54,7 +54,7 @@ class ModelTest extends PHPUnit_Framework_TestCase {
 
     public function testGetErrors()
     {
-        $model = m::mock('Way\Database\Model')->makePartial();
+        $model = m::mock('Andreyco\Database\Model')->makePartial();
         $model->setErrors('foo');
 
         $this->assertEquals('foo', $model->getErrors());
@@ -62,7 +62,7 @@ class ModelTest extends PHPUnit_Framework_TestCase {
 
     public function testHasErrors()
     {
-        $model = m::mock('Way\Database\Model')->makePartial();
+        $model = m::mock('Andreyco\Database\Model')->makePartial();
 
         $this->assertFalse($model->hasErrors());
 


### PR DESCRIPTION
This little change allows us to define/use rules like this

``` php
protected static $rules = [
    'email' => 'required|unique:users,email,:id:',
];
```

This little addition does not break any current code.
