### PR TITLE
Fixes #1 - Saving event should return null not true on success

### DIFF
--- a/src/Way/Database/Model.php
+++ b/src/Way/Database/Model.php
@@ -49,7 +49,8 @@ class Model extends Eloquent {
 
         static::saving(function($model)
         {
-            return $model->validate();
+            // Returning true would prevent other event listeners from firing
+            return $model->validate() ? null : false;
         });
     }
 


### PR DESCRIPTION
Ran into a compatability issue when using this package along with [eloquent-sluggable](https://github.com/cviebrock/eloquent-sluggable). This change allows other event listeners to fire when validation is successful.
