### PR TITLE
Fix broken Composer version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,9 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": ">=4.1.*,<=4.2.*",
-        "illuminate/database": ">=4.1.*,<=4.2.*",
-        "illuminate/validation": ">=4.1.*,<=4.2.*"
+        "illuminate/support": "~4.1",
+        "illuminate/database": "~4.1",
+        "illuminate/validation": "~4.1"
     },
     "require-dev": {
         "mockery/mockery": "dev-master"


### PR DESCRIPTION
The last commit added invalid version constraints to your composer.json file (see: https://getcomposer.org/doc/faqs/why-are-version-constraints-combining-comparisons-and-wildcards-a-bad-idea.md). This means that anybody who has been using your package won't be able to run `composer update`.

This change redoes the version constraints so that it is sensible and works as expected.
