### PR TITLE
Fixed a bug that prevented Model::saving() from being extended

### DIFF
--- a/src/Way/Database/Model.php
+++ b/src/Way/Database/Model.php
@@ -49,7 +49,7 @@ class Model extends Eloquent {
 
         static::saving(function($model)
         {
-            return $model->validate();
+            return ($model->validate() === false) ? false : null;
         });
     }
 


### PR DESCRIPTION
Laravel's event halting system prevents certain methods from cascading when any type of non-null content is returned. This is the case for the following methods:
- deleting
- saving
- creating
- updating

Since Model::boot() registers the `saving` event handler and _always_ returns either `true` or `false`, the `saving` event is effectively rendered useless for any code that wants to implement this on models that extend `\Way\Database\Model`.

**Proposed solution:** the `saving` event should _only_ return `false` on validation errors and should return _null_ on succesful validation.
