### PR TITLE
Allow child's saving events

### DIFF
--- a/src/Way/Database/Model.php
+++ b/src/Way/Database/Model.php
@@ -49,7 +49,10 @@ class Model extends Eloquent {
 
         static::saving(function($model)
         {
-            return $model->validate();
+			if( ! $model->validate())
+			{
+				return false;
+			}
         });
     }
 


### PR DESCRIPTION
Returning anything from the validating() function, will stop further saving() calls to execute.
So, if $model->validate() is false, false should be returned from saving() to prevent the model to be saved, otherwise nothing should be returned so futher (custom) saving() calls are allowed.
